### PR TITLE
V0.01 - Support for API endpoint `/manga-list`

### DIFF
--- a/app/db_definition.py
+++ b/app/db_definition.py
@@ -1,48 +1,54 @@
 from typing_extensions import Annotated
-from typing import List, Optional, Dict, Any
-from sqlalchemy import String, Float, ForeignKey, ARRAY, TEXT, INT, BOOLEAN
-from sqlalchemy.orm import Mapped, DeclarativeBase, mapped_column
-from sqlalchemy.orm.exc import DetachedInstanceError
+from sqlalchemy import ForeignKey, UUID, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, DeclarativeBase, mapped_column, relationship
 
-#table names
-MANGA_TABLE_NAME = 'manga'
-EPISODE_TABLE_NAME = 'episode'
+import uuid
 
-# customized type overrides
-str10 = Annotated[str, 5]
-str36 = Annotated[str, 36]
-str50 = Annotated[str, 50]
-str200 = Annotated[str, 200]
+# table names
+MANGA_TABLE_NAME = "manga"
+EPISODE_TABLE_NAME = "episode"
 
 # mapped column overrides
-uuid_pk = Annotated[str, mapped_column(String(36), primary_key=True, nullable=False, unique=True)]
+uuid_pk = Annotated[
+    str,
+    mapped_column(
+        uuid.UUID, primary_key=True, nullable=False, unique=True, default=uuid.uuid4
+    ),
+]
+
 
 class Base(DeclarativeBase):
     type_annotation_map = {
-        str10: String(10),
-        str36: String(36),
-        str50: String(50),
-        str200: String(200),
+        uuid.UUID: UUID(as_uuid=True),
+        str: Text,
     }
+
 
 class Manga(Base):
     __tablename__ = MANGA_TABLE_NAME
+    __table_args__ = (UniqueConstraint("manga_name", name="uq_manga_name"),)
 
     manga_id: Mapped[uuid_pk]
-    manga_name: Mapped[str50] = mapped_column(nullable=False, unique=True)
-    manga_link: Mapped[str200] = mapped_column(nullable=False, unique=True)
+    manga_name: Mapped[str] = mapped_column(Text, nullable=False)
+    manga_link: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Declare relationship w/ it's episodes (cascade delete)
+    episodes = relationship(
+        "Episode", back_populates="manga", cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:
-        return f'<Manga {self.manga_id}>'
+        return f"<Manga {self.manga_id}>"
+
 
 class Episode(Base):
     __tablename__ = EPISODE_TABLE_NAME
 
     episode_id: Mapped[uuid_pk]
-    manga_id: Mapped[str36] = mapped_column(ForeignKey('manga.manga_id'), nullable=False)
-    episode_name: Mapped[str10] = mapped_column(nullable=False, unique=True)
-    episode_link: Mapped[str200] = mapped_column(nullable=False, unique=True)
-    episode_tag: Mapped[str10] = mapped_column(unique=True)
+    manga_id: Mapped[str] = mapped_column(ForeignKey("manga.manga_id"), nullable=False)
+    episode_name: Mapped[str] = mapped_column(Text, nullable=False)
+    episode_link: Mapped[str] = mapped_column(Text, nullable=False)
+    episode_tag: Mapped[str] = mapped_column(Text)
 
     def __repr__(self) -> str:
-        return f'<Episode {self.episode_id}>'
+        return f"<Episode {self.episode_id}>"

--- a/app/db_definition.py
+++ b/app/db_definition.py
@@ -12,7 +12,7 @@ EPISODE_TABLE_NAME = "episode"
 uuid_pk = Annotated[
     str,
     mapped_column(
-        uuid.UUID, primary_key=True, nullable=False, unique=True, default=uuid.uuid4
+        UUID, primary_key=True, nullable=False, unique=True, default=uuid.uuid4
     ),
 ]
 
@@ -26,14 +26,17 @@ class Base(DeclarativeBase):
 
 class Manga(Base):
     __tablename__ = MANGA_TABLE_NAME
-    __table_args__ = (UniqueConstraint("manga_name", name="uq_manga_name"),)
 
     manga_id: Mapped[uuid_pk]
     manga_name: Mapped[str] = mapped_column(Text, nullable=False)
     manga_link: Mapped[str] = mapped_column(Text, nullable=False)
 
+    __table_args__ = (
+        UniqueConstraint("manga_name", "manga_link", name="uq_manga_name_link"),
+    )
+
     # Declare relationship w/ it's episodes (cascade delete)
-    episodes = relationship(
+    episodes: Mapped[list["Episode"]] = relationship(
         "Episode", back_populates="manga", cascade="all, delete-orphan"
     )
 
@@ -49,6 +52,8 @@ class Episode(Base):
     episode_name: Mapped[str] = mapped_column(Text, nullable=False)
     episode_link: Mapped[str] = mapped_column(Text, nullable=False)
     episode_tag: Mapped[str] = mapped_column(Text)
+
+    manga: Mapped[Manga] = relationship("Manga", back_populates="episodes")
 
     def __repr__(self) -> str:
         return f"<Episode {self.episode_id}>"

--- a/app/db_manager.py
+++ b/app/db_manager.py
@@ -2,6 +2,7 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.engine import URL
 
+
 class DB_Manager:
     def __init__(self) -> None:
         self.db = SQLAlchemy()
@@ -17,10 +18,11 @@ class DB_Manager:
             password="password",
             host="db",
             port="5432",
-            database="mydatabase"
+            database="mydatabase",
         )
 
         self.app.config["SQLALCHEMY_DATABASE_URI"] = DB_URL
         self.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+        self.app.json.ensure_ascii = False
 
         self.db.init_app(self.app)

--- a/app/scheduled_task.py
+++ b/app/scheduled_task.py
@@ -2,35 +2,35 @@
 from db_manager import DB_Manager
 from db_definition import Manga, Episode
 
+import uuid
+
+
 def run_task():
     dbman = DB_Manager()
-    
+
     # Add your logic to interact with the database
     with dbman.app.app_context():  # Ensure the app context is active
         mangas = dbman.db.session.query(Manga).all()
         # Perform operations with the data
-        for manga in mangas:
+        for i, manga in enumerate(mangas):
             print(manga.manga_name)
-        # Example: Update data
-        datum = [
-            Manga(manga_id='CD2FB8C8-1A3C-4CD0-A549-A816554CDF74',
-            manga_name='一拳超人',
-            manga_link='https://m.manhuagui.com/comic/7580/'),
-            Episode(
-            episode_id='8B80DA2B-358B-4DE3-8903-FBDBB7143969',
-            manga_id='CD2FB8C8-1A3C-4CD0-A549-A816554CDF74',
-            episode_name='New Episode',
-            episode_link='https://example.com',
-            episode_tag='new'
-        )]
-        dbman.db.session.add(datum[0])
-        dbman.db.session.flush()
-        dbman.db.session.add(datum[1])
+            print(manga.episodes)
+            dbman.db.session.add(
+                Episode(
+                    manga_id=manga.manga_id,
+                    episode_name=f"New Episode {i}",
+                    episode_link=f"https://example{i}.com",
+                    episode_tag="l",
+                )
+            )
+            dbman.db.session.flush()
         dbman.db.session.commit()
     print("scheduler run_task() finished")
 
+
 def test_job():
     print("scheduler test_job() finished")
+
 
 if __name__ == "__main__":
     run_task()

--- a/config/init.sql
+++ b/config/init.sql
@@ -1,18 +1,27 @@
-CREATE TABLE manga (
-    manga_id VARCHAR(36) NOT NULL PRIMARY KEY,
-    manga_name VARCHAR(50) NOT NULL,
-    manga_link VARCHAR(200) NOT NULL,
-    UNIQUE(manga_id, manga_name, manga_link)
+-- Create the manga table
+CREATE TABLE IF NOT EXISTS manga (
+    manga_id UUID PRIMARY KEY,
+    manga_name TEXT NOT NULL,
+    manga_link TEXT NOT NULL
 );
 
-CREATE TABLE episode (
-    episode_id VARCHAR(36) NOT NULL PRIMARY KEY,
-    manga_id VARCHAR(36) NOT NULL,
-    episode_name VARCHAR(50) NOT NULL,
-    episode_link VARCHAR(200) NOT NULL,
-    episode_tag VARCHAR(10),
-    UNIQUE(episode_id, episode_name, episode_link),
-    CONSTRAINT fk_episode_manga_id
-        FOREIGN KEY (manga_id)
-            REFERENCES manga(manga_id)
+-- Create the episodes table
+CREATE TABLE IF NOT EXISTS episodes (
+    episode_id UUID PRIMARY KEY,
+    manga_id UUID REFERENCES manga(manga_id),
+    episode_name TEXT NOT NULL,
+    episode_link TEXT NOT NULL,
+    episode_tag TEXT
 );
+
+-- Insert test data into the manga table
+INSERT INTO manga (manga_id, manga_name, manga_link) VALUES
+('A2E7AD9B-6CD2-4C0C-BD33-EF7E6FD35909', '一拳超人', 'https://m.manhuagui.com/comic/7580/'),
+('4611FF5E-B6E8-4645-8E44-60A59204939B', '每遭放逐就能获得技能的我，在100个世界大开第二轮无双', 'https://m.manhuagui.com/comic/50667/'),
+('A6F6C87B-64BD-4338-B451-2DB9CC0CBE91', '怪兽8号', 'https://m.manhuagui.com/comic/36859/');
+
+-- Insert test data into the episodes table
+INSERT INTO episodes (episode_id, manga_id, episode_name, episode_link, episode_tag) VALUES
+('F6F781B9-CA35-441A-9016-DDC5547F4D60', 'A2E7AD9B-6CD2-4C0C-BD33-EF7E6FD35909', '第247话重置版', 'https://m.manhuagui.com/comic/7580/772434.html', ''),
+('66F67364-32AC-4E41-9033-FE4EB1F3AC65', '4611FF5E-B6E8-4645-8E44-60A59204939B', '第5话', 'https://m.manhuagui.com/comic/50667/772823.html', ''),
+('3ACA1D34-0FAA-4DE2-A432-A6F42FC78B30', 'A6F6C87B-64BD-4338-B451-2DB9CC0CBE91', '第112话', 'https://m.manhuagui.com/comic/36859/771479.html', '');

--- a/config/init.sql
+++ b/config/init.sql
@@ -2,16 +2,20 @@
 CREATE TABLE IF NOT EXISTS manga (
     manga_id UUID PRIMARY KEY,
     manga_name TEXT NOT NULL,
-    manga_link TEXT NOT NULL
+    manga_link TEXT NOT NULL,
+
+    UNIQUE (manga_name, manga_link)
 );
 
--- Create the episodes table
-CREATE TABLE IF NOT EXISTS episodes (
+-- Create the episode table
+CREATE TABLE IF NOT EXISTS episode (
     episode_id UUID PRIMARY KEY,
-    manga_id UUID REFERENCES manga(manga_id),
+    manga_id UUID NOT NULL,
     episode_name TEXT NOT NULL,
     episode_link TEXT NOT NULL,
-    episode_tag TEXT
+    episode_tag TEXT,
+
+    FOREIGN KEY (manga_id) REFERENCES manga(manga_id)
 );
 
 -- Insert test data into the manga table
@@ -21,7 +25,7 @@ INSERT INTO manga (manga_id, manga_name, manga_link) VALUES
 ('A6F6C87B-64BD-4338-B451-2DB9CC0CBE91', '怪兽8号', 'https://m.manhuagui.com/comic/36859/');
 
 -- Insert test data into the episodes table
-INSERT INTO episodes (episode_id, manga_id, episode_name, episode_link, episode_tag) VALUES
+INSERT INTO episode (episode_id, manga_id, episode_name, episode_link, episode_tag) VALUES
 ('F6F781B9-CA35-441A-9016-DDC5547F4D60', 'A2E7AD9B-6CD2-4C0C-BD33-EF7E6FD35909', '第247话重置版', 'https://m.manhuagui.com/comic/7580/772434.html', ''),
 ('66F67364-32AC-4E41-9033-FE4EB1F3AC65', '4611FF5E-B6E8-4645-8E44-60A59204939B', '第5话', 'https://m.manhuagui.com/comic/50667/772823.html', ''),
 ('3ACA1D34-0FAA-4DE2-A432-A6F42FC78B30', 'A6F6C87B-64BD-4338-B451-2DB9CC0CBE91', '第112话', 'https://m.manhuagui.com/comic/36859/771479.html', '');

--- a/config/init.sql
+++ b/config/init.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS episode (
     manga_id UUID NOT NULL,
     episode_name TEXT NOT NULL,
     episode_link TEXT NOT NULL,
-    episode_tag TEXT,
+    episode_tag TEXT, -- l=latest, c=currently_on
 
     FOREIGN KEY (manga_id) REFERENCES manga(manga_id)
 );
@@ -26,6 +26,6 @@ INSERT INTO manga (manga_id, manga_name, manga_link) VALUES
 
 -- Insert test data into the episodes table
 INSERT INTO episode (episode_id, manga_id, episode_name, episode_link, episode_tag) VALUES
-('F6F781B9-CA35-441A-9016-DDC5547F4D60', 'A2E7AD9B-6CD2-4C0C-BD33-EF7E6FD35909', '第247话重置版', 'https://m.manhuagui.com/comic/7580/772434.html', ''),
-('66F67364-32AC-4E41-9033-FE4EB1F3AC65', '4611FF5E-B6E8-4645-8E44-60A59204939B', '第5话', 'https://m.manhuagui.com/comic/50667/772823.html', ''),
-('3ACA1D34-0FAA-4DE2-A432-A6F42FC78B30', 'A6F6C87B-64BD-4338-B451-2DB9CC0CBE91', '第112话', 'https://m.manhuagui.com/comic/36859/771479.html', '');
+('F6F781B9-CA35-441A-9016-DDC5547F4D60', 'A2E7AD9B-6CD2-4C0C-BD33-EF7E6FD35909', '第247话重置版', 'https://m.manhuagui.com/comic/7580/772434.html', 'c'),
+('66F67364-32AC-4E41-9033-FE4EB1F3AC65', '4611FF5E-B6E8-4645-8E44-60A59204939B', '第5话', 'https://m.manhuagui.com/comic/50667/772823.html', 'c'),
+('3ACA1D34-0FAA-4DE2-A432-A6F42FC78B30', 'A6F6C87B-64BD-4338-B451-2DB9CC0CBE91', '第112话', 'https://m.manhuagui.com/comic/36859/771479.html', 'c');

--- a/design-notes/backend_APIs.md
+++ b/design-notes/backend_APIs.md
@@ -1,0 +1,35 @@
+## /manga-list
+
+#### Schema
+{
+    mangas: [
+        {
+            name: "一拳超人",
+            link: "https://m.manhuagui.com/comic/7580/",
+            episode_latest: {
+                name: "第5话",
+                link: "https://m.manhuagui.com/comic/7580/772479.html",
+            }
+            episode_currently_on: {
+                name: "第2话",
+                link: "https://m.manhuagui.com/comic/7580/772479.html",
+            }
+        },
+        {
+            name: "怪兽8号",
+            link: "https://m.manhuagui.com/comic/36859/",
+            episode_latest: {
+                name: "第247话重置版",
+                link: "https://m.manhuagui.com/comic/36859/772479.html",
+            }
+            episode_currently_on: {
+                name: "第222话",
+                link: "https://m.manhuagui.com/comic/36859/771479.html",
+            }
+        },
+        ...
+    ]
+}
+
+#### Notes
+- Each manga will have 2 episode children - latest and currently_on


### PR DESCRIPTION
Key changes:
- /manga-list api endpoint now should function as the schema presented in `design-notes/backend_APIs.md`
- manga/episode fields no longer have character limits (VARCHAR -> TEXT)
- Misc changes setting up for future tickets